### PR TITLE
Use the pre-built image as the default

### DIFF
--- a/demo/daemonset.yaml
+++ b/demo/daemonset.yaml
@@ -22,7 +22,7 @@
               - name: "IPTABLES_LOG_PREFIX"
                 # log prefix defined in your iptables chains
                 value: "calico-drop:"
-            image: "kube-iptables-tailer:v0.1.0"
+            image: "boxinc/kube-iptables-tailer:v0.1.0"
             volumeMounts: 
               - name: "iptables-logs"
                 mountPath: "/var/log"


### PR DESCRIPTION
The commit updated `daemonset.yaml` to use the pre-built image as the default, this change can help the user quickly deploy kube-iptables-tailer without manually building an image from source.