### PR TITLE
Allow identification of pods by a label defined in environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ We suggest running kube-iptables-tailer as a [Daemonset](https://kubernetes.io/d
 * `PACKET_DROP_EXPIRATION_MINUTES`: (int, default: **10**) Expiration of a packet drop in minutes. Any dropped packet log entries older than this duration will be ignored.
 * `REPEATED_EVENTS_INTERVAL_MINUTES`: (int, default: **2**) Interval of ignoring repeated packet drops in minutes. Any dropped packet log entries with the same source and destination will be ignored if already submitted once within this time period. 
 * `WATCH_LOGS_INTERVAL_SECONDS`: (int, default: **5**) Interval of detecting log changes in seconds. 
-* `POD_IDENTIFIER`: (string, default: **namespace**) How to identify pods in the logs. `name` or `namespace` are currently supported.
+* `POD_IDENTIFIER`: (string, default: **namespace**) How to identify pods in the logs. `name`, `label` or `namespace` are currently supported. If `label`, uses the value of the label key specified by `POD_IDENTIFIER_LABEL`.
+* `POD_IDENTIFIER_LABEL`: (string) Pod label key with which to identify pods if `POD_IDENTIFIER` is set to `label`. If this label doesn't exist on the pod, the pod name is used instead.
 
 ### Metrics 
 Metrics are implemented by Prometheus, which are hosted on the web server at `/metrics`. The metrics have a name `packet_drops_count` and counter with the following tags:

--- a/event/locator.go
+++ b/event/locator.go
@@ -129,9 +129,15 @@ func (locator *PodLocator) LocatePod(ip string) (*v1.Pod, error) {
 func getNamespaceOrHostName(pod *v1.Pod, ip string, resolver DnsResolver) string {
 	if pod != nil {
 		if !pod.Spec.HostNetwork {
-			identifier := util.GetEnvStringOrDefault(util.PodIdentifer, util.DefaultPodIdentifier)
+			identifier := util.GetEnvStringOrDefault(util.PodIdentifier, util.DefaultPodIdentifier)
 			switch identifier {
 			case "name":
+				return pod.Name
+			case "label":
+				labelKey := util.GetRequiredEnvString(util.PodIdentifierLabel)
+				if labelValue, ok := pod.Labels[labelKey]; ok {
+					return labelValue
+				}
 				return pod.Name
 			case "namespace":
 				return pod.Namespace

--- a/util/envar.go
+++ b/util/envar.go
@@ -37,8 +37,9 @@ const (
 	WatchLogsIntervalSeconds       = "WATCH_LOGS_INTERVAL_SECONDS"
 	DefaultWatchLogsIntervalSecond = 5
 
-	PodIdentifer         = "POD_IDENTIFIER"
+	PodIdentifier        = "POD_IDENTIFIER"
 	DefaultPodIdentifier = "namespace"
+	PodIdentifierLabel   = "POD_IDENTIFIER_LABEL"
 )
 
 func GetRequiredEnvString(key string) string {


### PR DESCRIPTION
Pod name identification is cool, but being able to specify custom labels is probably more cool. At monzo we use this with an `app` label and it makes for neater graphs.