### PR TITLE
Add required .spec.selector for demo daemonset

### DIFF
--- a/demo/daemonset.yaml
+++ b/demo/daemonset.yaml
@@ -5,6 +5,9 @@
     name: "kube-iptables-tailer"
     namespace: "kube-system"
   spec: 
+    selector:
+      matchLabels:
+        app: "kube-iptables-tailer"
     template:
       metadata:
         labels:


### PR DESCRIPTION
Per https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/,

`As of Kubernetes 1.8, you must specify a pod selector that matches the labels of the .spec.template. The pod selector will no longer be defaulted when left empty. Selector defaulting was not compatible with kubectl apply. Also, once a DaemonSet is created, its .spec.selector can not be mutated. Mutating the pod selector can lead to the unintentional orphaning of Pods, and it was found to be confusing to users.`

Fixes #13 