### PR TITLE
Add setting to change log time layout (fixes #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ kube-iptables-tailer is a service that gives you better visibility on networking
 
 kube-iptables-tailer itself runs as a Pod in your cluster, and it keeps watching changes on iptables log file [mounted from the host](#mounting-iptables-log-file). If traffic from/to a Pod is denied by your iptables rules, iptables will drop the packet and record a log entry on the host with relevant information. kube-iptables-tailer is able to detect these changes, and then it will try locating both the senders and receivers (as running Pods in your cluster) by their IPs. For IPs that do not match any Pods in your cluster, a DNS lookup will be performed to get subjects involved in the packet drops.
 
-As the result, kube-iptables-tailer will submit an event in nearly real-time to the Pod located successfully inside your cluster. The Pod owners can thence be aware of iptables packet drops simply by running the following command:  
+As the result, kube-iptables-tailer will submit an event in nearly real-time to the Pod located successfully inside your cluster. The Pod owners can thence be aware of iptables packet drops simply by running the following command:
 
 ```shell
 $ kubectl describe pods --namespace=YOUR_NAMESPACE
@@ -17,7 +17,7 @@ Events:
   FirstSeen   LastSeen    Count   From                    Type          Reason          Message
   ---------   --------	  -----	  ----                    ----          ------          -------
   1h          5s          10      kube-iptables-tailer    Warning       PacketDrop      Packet dropped when receiving traffic from example-service-2 (22.222.22.222) on port 5678/TCP.
-  
+
   3h          2m          5       kube-iptables-tailer    Warning       PacketDrop      Packet dropped when sending traffic to example-service-1 (11.111.11.111) on port 1234/TCP.
 ```
 **NOTE**: Content under the sections `From`, `Reason`, and `Message` showing in the above output can be configured in your container spec file. Please refer to the corresponding [environment variables](#environment-variables) below for a more detailed explanation.
@@ -40,44 +40,45 @@ $ cd <path-to-the-source-code>
 $ make container
 ```
 
-## Usage 
+## Usage
 
 ### Setup iptables Log Prefix
-kube-iptables-tailer uses log-prefix defined in your iptables chains to parse the corresponding packet dropped logs. You can set up the log-prefix by executing the following command (root permission might be required):    
+kube-iptables-tailer uses log-prefix defined in your iptables chains to parse the corresponding packet dropped logs. You can set up the log-prefix by executing the following command (root permission might be required):
 ```shell
 $ iptables -A CHAIN_NAME -j LOG --log-prefix "EXAMPLE_LOG_PREFIX: "
-```  
+```
 
-Any packets dropped by this chain will be logged containing the given log prefix:  
-`2019-02-04T10:10:12.345678-07:00 hostname EXAMPLE_LOG_PREFIX: SRC=SOURCE_IP DST=DESTINATION_IP ...`  
+Any packets dropped by this chain will be logged containing the given log prefix:
+`2019-02-04T10:10:12.345678-07:00 hostname EXAMPLE_LOG_PREFIX: SRC=SOURCE_IP DST=DESTINATION_IP ...`
 For more information on iptables command, please refer to this [Linux man page](https://linux.die.net/man/8/iptables).
 
 ### Mounting iptables Log File
-The parent **directory** of your iptables log file needs to be mounted for kube-iptables-tailer to handle log rotation properly. The service could not get updated content after the file is rotated if you only mount the log file. This is because files are mounted into the container with specific [inode](https://en.wikipedia.org/wiki/Inode) numbers, which remain the same even if the file names are changed on the host (usually happens after rotation).   
+The parent **directory** of your iptables log file needs to be mounted for kube-iptables-tailer to handle log rotation properly. The service could not get updated content after the file is rotated if you only mount the log file. This is because files are mounted into the container with specific [inode](https://en.wikipedia.org/wiki/Inode) numbers, which remain the same even if the file names are changed on the host (usually happens after rotation).
 kube-iptables-tailer also applies a fingerprint for the current log file to handle log rotation as well as avoid reading the entire log file every time when its content get updated.
 
 ### Container Spec
 We suggest running kube-iptables-tailer as a [Daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) in your cluster. An example of YAML spec file can be found in [demo/](demo/).
 
-### Environment Variables 
+### Environment Variables
 
-#### Required: 
-* `IPTABLES_LOG_PATH` or `JOURNAL_DIRECTORY`: (string) Absolute path to your iptables log file, or journald directory including the full path. 
+#### Required:
+* `IPTABLES_LOG_PATH` or `JOURNAL_DIRECTORY`: (string) Absolute path to your iptables log file, or journald directory including the full path.
 * `IPTABLES_LOG_PREFIX`: (string) Log prefix defined in your iptables chains. The service will only handle the logs matching this log prefix exactly.
 
 #### Optional:
 * `KUBE_API_SERVER`: (string) Address of the Kubernetes API server. By default, the discovery of the API server is handled by kube-proxy. If kube-proxy is not set up, the API server address must be specified with this environment variable. Authentication to the API server is handled by service account tokens. See [Accessing the Cluster](http://kubernetes.io/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod) for more info.
 * `KUBE_EVENT_DISPLAY_REASON`: (string, default: **PacketDrop**) A brief and UpperCamelCase formatted text showing under the [Reason](https://godoc.org/k8s.io/client-go/tools/record#EventRecorder) section in the event sent from this service.
-* `KUBE_EVENT_SOURCE_COMPONENT_NAME`: (string, default: **kube-iptables-tailer**) A name showing under the From section to indicate the [source](https://godoc.org/k8s.io/api/core/v1#EventSource) of the Kubernetes event. 
+* `KUBE_EVENT_SOURCE_COMPONENT_NAME`: (string, default: **kube-iptables-tailer**) A name showing under the From section to indicate the [source](https://godoc.org/k8s.io/api/core/v1#EventSource) of the Kubernetes event.
 * `METRICS_SERVER_PORT`: (int, default: **9090**) Port for the service to host its metrics.
 * `PACKET_DROP_CHANNEL_BUFFER_SIZE`: (int, default: **100**) Size of the channel for existing items to handle. You may need to increase this value if you have a high rate of packet drops being recorded.
 * `PACKET_DROP_EXPIRATION_MINUTES`: (int, default: **10**) Expiration of a packet drop in minutes. Any dropped packet log entries older than this duration will be ignored.
-* `REPEATED_EVENTS_INTERVAL_MINUTES`: (int, default: **2**) Interval of ignoring repeated packet drops in minutes. Any dropped packet log entries with the same source and destination will be ignored if already submitted once within this time period. 
-* `WATCH_LOGS_INTERVAL_SECONDS`: (int, default: **5**) Interval of detecting log changes in seconds. 
+* `REPEATED_EVENTS_INTERVAL_MINUTES`: (int, default: **2**) Interval of ignoring repeated packet drops in minutes. Any dropped packet log entries with the same source and destination will be ignored if already submitted once within this time period.
+* `WATCH_LOGS_INTERVAL_SECONDS`: (int, default: **5**) Interval of detecting log changes in seconds.
 * `POD_IDENTIFIER`: (string, default: **namespace**) How to identify pods in the logs. `name`, `label`, `namespace` or `name_with_namespace` are currently supported. If `label`, uses the value of the label key specified by `POD_IDENTIFIER_LABEL`.
 * `POD_IDENTIFIER_LABEL`: (string) Pod label key with which to identify pods if `POD_IDENTIFIER` is set to `label`. If this label doesn't exist on the pod, the pod name is used instead.
+* `PACKET_DROP_LOG_TIME_LAYOUT`: (string) [Golang Time layout](https://godoc.org/time#Parse) used to parse the log time
 
-### Metrics 
+### Metrics
 Metrics are implemented by Prometheus, which are hosted on the web server at `/metrics`. The metrics have a name `packet_drops_count` and counter with the following tags:
 * `src`: The namespace of sender Pod involved with a packet drop.
 * `dst`: The namespace of receiver Pod involved with a packet drop.
@@ -86,7 +87,7 @@ Metrics are implemented by Prometheus, which are hosted on the web server at `/m
 Logging is implemented using [glog](https://godoc.org/github.com/golang/glog). To change the output directory of logs, you can mount an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) as a volume (where containers can have read and write access of the files inside) and add `--log_dir` as a command argument. Refer to [daemonset.yaml](demo/daemonset.yaml) provided as an example.
 
 ## Contribution
-All contributions are welcome to this project! Please review our [contributing guidelines](CONTRIBUTING.md) to facilitate the process of your contribution getting mereged. 
+All contributions are welcome to this project! Please review our [contributing guidelines](CONTRIBUTING.md) to facilitate the process of your contribution getting mereged.
 
 ## Support
 Need to contact us directly? Email oss@box.com and be sure to include the name of this project in the subject.

--- a/drop/journal_watcher_cgo.go
+++ b/drop/journal_watcher_cgo.go
@@ -43,7 +43,7 @@ func (watcher *JournalWatcher) Run(logChangeCh chan<- string) {
 
 			return strings.Join([]string{
 				time.Unix(0, int64(entry.RealtimeTimestamp)*int64(time.Microsecond)).
-					Format(PacketDropLogTimeLayout),
+					Format(DefaultPacketDropLogTimeLayout),
 				hostname,
 				msg,
 			}, " ") + "\n", nil

--- a/event/poster.go
+++ b/event/poster.go
@@ -3,21 +3,22 @@ package event
 import (
 	"errors"
 	"fmt"
+	"net"
+	"os"
+	"time"
+
 	"github.com/box/kube-iptables-tailer/drop"
 	"github.com/box/kube-iptables-tailer/metrics"
 	"github.com/box/kube-iptables-tailer/util"
 	"github.com/cenkalti/backoff"
 	"github.com/golang/glog"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/tools/reference"
-	"net"
-	"os"
-	"time"
 )
 
 // Poster handles submitting Kubernetes Events to Pods running in the cluster.
@@ -125,8 +126,7 @@ func (poster *Poster) shouldIgnore(packetDrop drop.PacketDrop) bool {
 		glog.Infof("Ignoring expired packet drop: packetDrop=%+v", packetDrop)
 		return true
 	}
-	// ignore if the event has been posted within the defined time period
-	logTime, _ := packetDrop.GetLogTime() //  the error would be handled in expiration check called above
+	logTime := packetDrop.GetLogTime() //  the error would be handled in expiration check called above
 	key := packetDrop.SrcIP + packetDrop.DstIP
 	lastPostedTime := poster.eventSubmitTimeMap[key]
 	repeatEventIntervalMinutes := float64(util.GetEnvIntOrDefault(

--- a/util/envar.go
+++ b/util/envar.go
@@ -29,6 +29,9 @@ const (
 	PacketDropChannelBufferSize         = "PACKET_DROP_CHANNEL_BUFFER_SIZE"
 	DefaultPacketDropsChannelBufferSize = 100
 
+	PacketDropLogTimeLayout        = "PACKET_DROP_LOG_TIME_LAYOUT"
+	DefaultPacketDropLogTimeLayout = "2006-01-02T15:04:05.000000-07:00"
+
 	PacketDropExpirationMinutes        = "PACKET_DROP_EXPIRATION_MINUTES"
 	DefaultPacketDropExpirationMinutes = 10
 

--- a/util/util.go
+++ b/util/util.go
@@ -3,8 +3,9 @@ package util
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
 	"time"
+
+	"github.com/golang/glog"
 )
 
 func PrettyPrint(i interface{}) string {
@@ -18,8 +19,8 @@ func PrettyPrint(i interface{}) string {
 }
 
 // Utility functions for packet drop testing
-func GetExpiredTimeInString(expirationMinutes int, timeFormat string) string {
+func GetExpiredTimeIn(expirationMinutes int) time.Time {
 	duration := time.Duration(expirationMinutes) * time.Minute
 	// add one more minute than given expiration to make sure the time is expired
-	return time.Now().Add(-duration - time.Minute).Format(timeFormat)
+	return time.Now().Add(-duration - time.Minute)
 }


### PR DESCRIPTION
Allows to add a `PACKET_DROP_LOG_TIME_LAYOUT` environment variable to set the layout that will be used to parse the log time.

Fixes #10

