### PR TITLE
Don't fail if MAC field is not present

### DIFF
--- a/drop/parser.go
+++ b/drop/parser.go
@@ -3,10 +3,11 @@ package drop
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/zap/zapcore"
 	"reflect"
 	"strings"
 	"time"
+
+	"go.uber.org/zap/zapcore"
 
 	"github.com/box/kube-iptables-tailer/util"
 	"go.uber.org/zap"
@@ -159,10 +160,10 @@ func getPacketDrop(packetDropLog, logTimeLayout string) (PacketDrop, error) {
 	if err != nil {
 		return PacketDrop{}, err
 	}
-	macAddress, err := getFieldValue(logFields, fieldMacAddress)
-	if err != nil {
-		return PacketDrop{}, err
-	}
+
+	// Logs don't always contain the MAC field
+	macAddress, _ := getFieldValue(logFields, fieldMacAddress)
+
 	ttl, err := getFieldValue(logFields, fieldTtl)
 	if err != nil {
 		return PacketDrop{}, err


### PR DESCRIPTION
Sometimes the MAC field is not present in the iptables logs. Let's make this field optional so we can avoid this error and report the rejected packet.

```json
{
"level":"error","timestamp":"2021-05-03T08:53:49.180Z",
"caller":"drop/watcher.go:41",
"msg":"Failed to open file","file":"/var/log/calico/calico-packet-rejected.log",
"error":"open /var/log/calico/calico-packet-rejected.log: no such file or directory","stacktrace":"github.com/box/kube-iptables-tailer/drop.(*Watcher).checkFile\n\t/go/src/github.com/box/kube-iptables-tailer/drop/watcher.go:41\ngithub.com/box/kube-iptables-tailer/drop.(*Watcher).Run\n\t/go/src/github.com/box/kube-iptables-tailer/drop/watcher.go:33\nmain.startWatcher\n\t/go/src/github.com/box/kube-iptables-tailer/main.go:84"
}
```

```
2021-04-05T14:16:31+00:00 kube-node-(redacted) kernel: calico-packet: IN= OUT=eth1 SRC=(redacted) DST=(redacted) LEN=60 TOS=0x10 PREC=0x00 TTL=63 ID=26035 DF PROTO=TCP SPT=39864 DPT=4317 WINDOW=64240 RES=0x00 SYN URGP=0 MARK=0x73800000 
```