### PR TITLE
Reduce logging

### DIFF
--- a/event/locator.go
+++ b/event/locator.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/box/kube-iptables-tailer/util"
 	"go.uber.org/zap"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"time"
 )
 
 // DnsResolver allows for mocking out the functionality of net.DefaultResolver when testing getPacketDropMessage()
@@ -210,7 +211,7 @@ func getHostName(resolver DnsResolver, ipAddress string) string {
 	addr, err := resolver.LookupAddr(context.Background(), ipAddress)
 	if err != nil || len(addr) == 0 {
 		if err != nil {
-			zap.L().Error(
+			zap.L().Info(
 				"Unable to resolve address",
 				zap.String("ip", ipAddress),
 				zap.String("error", err.Error()),


### PR DESCRIPTION
Even at the `warn` level we still get logs for things that I would consider normal behaviors.

This PR attempt to reduce them at two different places:

**1 - While looking for the reverse dns of the IP Adresses:**

Having an IP that cannot resolve into a domain is not an Error, it is indeed less convenient,
but some IP Addresses might not have their Reverse DNS setup.

**2 - While looking for the log file:**

Some setup might not create the log file until a packet is logged, resulting in a lot of logs complaining about the file not being present. Instead we can print this error only once.