### PR TITLE
use latest ubuntu docker image

### DIFF
--- a/Dockerfile-cgo
+++ b/Dockerfile-cgo
@@ -1,4 +1,4 @@
-FROM ubuntu as builder
+FROM ubuntu:jammy as builder
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y golang git libsystemd-dev make
 ENV GOPATH /root/go
@@ -6,7 +6,7 @@ WORKDIR $GOPATH/src/github.com/box/kube-iptables-tailer
 COPY . $GOPATH/src/github.com/box/kube-iptables-tailer
 RUN make build-cgo
 
-FROM ubuntu
+FROM ubuntu:jammy
 LABEL maintainer="Saifuding Diliyaer <sdiliyaer@box.com>"
 WORKDIR /root/
 COPY --from=builder /root/go/src/github.com/box/kube-iptables-tailer/kube-iptables-tailer /kube-iptables-tailer


### PR DESCRIPTION
since older one is giving error or atleast the alipne docker image and I couldn't find the docker image for the dockerfile-cgo build one

```
{"level":"error","timestamp":"2022-03-30T10:45:51.240Z","caller":"event/poster.go:72","msg":"Error retrying packet drop handling, backing off","packet_drop":{"pkt_log_time":"2022-03-30T10:35:53.429Z","pkt_src_ip":"172.20.196.173","pkt_src_port":"43114","pkt_dst_ip":"172.20.30.40","pkt_dst_port":"53","pkt_proto":"UDP","pkt_ttl":"62","pkt_mac_addr":"","pkt_interface_recv":"tunl0","pkt_interface_sent":"calif32b9156d0f"},"retry":0.924353697,"error":"selfLink was empty, can't make reference","stacktrace":"github.com/box/kube-iptables-t
ailer/event.(*Poster).Run.func2\n\t/root/go/src/github.com/box/kube-iptables-tailer/event/poster.go:72\ngithub.com/box/kube-iptables-tailer/vendor/github.com/cenkalti/backoff.RetryNotify\n\t/root/go/src/github.com/box/kube-iptables-tailer/vendor/github.com/cenkalti/backoff/retry.go:49\ngithub.com/box/kube-iptables-tailer/event.(*Poster).Run\n\t/root/go/src/github.com/box/kube-iptables-tailer/event/poster.go:80\nmain.startPoster\n\t/root/go/src/github.com/box/kube-iptables-tailer/main.go:78"}
```

Similar issue reported here https://github.com/box/kube-iptables-tailer/issues/28